### PR TITLE
Allow emoji that use dashes to separate words

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,7 +1,7 @@
 const visit = require('unist-util-visit');
 const emoji = require('node-emoji');
 
-const RE_EMOJI = /:\+1:|:-1:|:\w+:/g;
+const RE_EMOJI = /:\+1:|:-1:|:[\w-]+:/g;
 
 function plugin(_, settings) {
     const pad = !!(settings || {}).padSpaceAfter;

--- a/index_test.js
+++ b/index_test.js
@@ -85,4 +85,15 @@ describe('remark-emoji', () => {
             Object.keys(cases).map(c => processPad(c).then(r => assert.equal(r, cases[c])))
         );
     });
+
+    it('can handle emoji that use dashes to separate words instead of underscores', () => {
+        const cases = {
+            'The Antarctic flag is represented by :flag-aq:': 'The Antarctic flag is represented by 🇦🇶\n',
+            ':man-woman-girl-boy:': '👨‍👩‍👧‍👦\n'
+        };
+
+        return Promise.all(
+            Object.keys(cases).map(c => process(c).then(r => assert.equal(r, cases[c])))
+        );
+    });
 });


### PR DESCRIPTION
Some emoji added in the [latest addition](https://github.com/omnidan/node-emoji/commit/452cf80350cb9a90ccf444ef976e13e5e13fb217) to node-emoji use a dash `-` to separate the parts of the name, rather than an underscore.

This pull request adds a dash to the regular expression, allowing the use of flags, families, and skin tone modifiers. Test have also been added.

---

Side note: The `:-1:` entry in the regular expression is no longer required, since `[\w-]+` covers that. I've left it in so the `:+1:` doesn't look completely out of place, although it'd take no time at all to remove it.