### PR TITLE
Update ESLint

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -27,9 +27,11 @@
       "ecmaVersion": 6
     },
     "extends": "eslint:recommended",
-    "ecmaFeatures": {
-        "jsx": true,
-        "modules": true,
-        "experimentalObjectRestSpread": true
+    "parserOptions": {
+        "ecmaFeatures": {
+            "jsx": true,
+            "modules": true,
+            "experimentalObjectRestSpread": true
+        }
     }
 }

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   },
   "homepage": "https://github.com/rhysd/remark-emoji#readme",
   "devDependencies": {
-    "eslint": "^3.7.0",
+    "eslint": "^4.0.0",
     "mocha": "^3.1.0",
     "remark": "^7.0.0",
     "remark-autolink-headings": "^5.0.0",


### PR DESCRIPTION
Hi! 👋

Sorry I just pushed a broken commit. It’s all fixed now!

This commit updates ESLint on its own. Apparently they no longer support `ecmaFeatures` in the top-level config object anymore, and it [should be a parser option](http://eslint.org/docs/4.0.0/user-guide/configuring.html#specifying-parser-options).

I moved everything under `parserOptions`, and things work, but I’m unsure about the `"modules": true` option, as it isn’t highlighted anywhere in their docs?

Cheers,
Titus