### PR TITLE
change: replaced arrow function in transformer visitor.

### DIFF
--- a/index.js
+++ b/index.js
@@ -16,7 +16,7 @@ function plugin(settings) {
     }
 
     function transformer(tree) {
-        visit(tree, 'text', node => {
+        visit(tree, 'text', function (node) {
             node.value = node.value.replace(RE_EMOJI, getEmoji);
         });
     }


### PR DESCRIPTION
This change will fix #4. CRA (create-react-app) complains with modules containing non ES5 syntax when compiling a production build.
This PR changes the arrow function used in the visitor in favor of a normal function.