### PR TITLE
Add emoticon support

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,10 +1,24 @@
 const visit = require('unist-util-visit');
 const emoji = require('node-emoji');
+const emoticon = require('emoticon');
 
 const RE_EMOJI = /:\+1:|:-1:|:[\w-]+:/g;
+const RE_SHORT = /[$@|*',;.=:\-)([\]\\/<>038BOopPsdDxXzZ]{2,5}/g;
 
 function plugin(settings) {
     const pad = !!(settings || {}).padSpaceAfter;
+
+    function getEmojiByShortCode(match) {
+        // find emoji by shortcode - full match or with-out last char as it could be from text e.g. :-), 
+        const iconFull = emoticon.find(e => e.emoticons.includes(match)); // full match
+        const iconPart = emoticon.find(e => e.emoticons.includes(match.slice(0, -1))); // second search pattern
+        const trimmedChar = iconPart ? match.slice(-1): '';
+        const addPad = pad ? ' ': '';
+        let icon = iconFull ?
+            iconFull.emoji + addPad: 
+            iconPart && (iconPart.emoji + addPad +  trimmedChar);
+        return icon || match;
+    }
 
     function getEmoji(match) {
         const got = emoji.get(match);
@@ -17,6 +31,11 @@ function plugin(settings) {
     function transformer(tree) {
         visit(tree, 'text', function(node) {
             node.value = node.value.replace(RE_EMOJI, getEmoji);
+            
+            if (!RE_EMOJI.test(node.value)) {
+                // emoji regex not matching --> check if shortcode
+                node.value = node.value.replace(RE_SHORT, getEmojiByShortCode);
+            }
         });
     }
 

--- a/index.js
+++ b/index.js
@@ -3,7 +3,7 @@ const emoji = require('node-emoji');
 const emoticon = require('emoticon');
 
 const RE_EMOJI = /:\+1:|:-1:|:[\w-]+:/g;
-const RE_SHORT = /[$@|*',;.=:\-)([\]\\/<>038BOopPsSdDxXzZ]{2,5}/g;
+const RE_SHORT = /[$@|*'",;.=:\-)([\]\\/<>038BOopPsSdDxXzZ]{2,5}/g;
 
 function plugin(settings) {
     const pad = !!(settings || {}).padSpaceAfter;

--- a/index.js
+++ b/index.js
@@ -40,7 +40,6 @@ function plugin(options) {
             node.value = node.value.replace(RE_EMOJI, getEmoji);
             
             if (emoticonEnable) {
-                // emoji regex not matching --> check if shortcode
                 node.value = node.value.replace(RE_SHORT, getEmojiByShortCode);
             }
         });

--- a/index.js
+++ b/index.js
@@ -37,10 +37,9 @@ function plugin(options) {
 
     function transformer(tree) {
         visit(tree, 'text', function(node) {
-            before = node.value;
-            node.value = before.replace(RE_EMOJI, getEmoji);
+            node.value = node.value.replace(RE_EMOJI, getEmoji);
             
-            if (emoticonEnable && node.value === before) {
+            if (emoticonEnable) {
                 // emoji regex not matching --> check if shortcode
                 node.value = node.value.replace(RE_SHORT, getEmojiByShortCode);
             }

--- a/index.js
+++ b/index.js
@@ -5,8 +5,16 @@ const emoticon = require('emoticon');
 const RE_EMOJI = /:\+1:|:-1:|:[\w-]+:/g;
 const RE_SHORT = /[$@|*'",;.=:\-)([\]\\/<>038BOopPsSdDxXzZ]{2,5}/g;
 
-function plugin(settings) {
-    const pad = !!(settings || {}).padSpaceAfter;
+const DEFAULT_SETTINGS = {
+    padSpaceAfter: false,
+    emoticon: false
+};
+
+function plugin(options) {
+    //const pad = !!(settings || {}).padSpaceAfter;
+    const settings = Object.assign(DEFAULT_SETTINGS, options);
+    const pad = !!settings.padSpaceAfter;
+    const emoticonEnable = !!settings.emoticon;
 
     function getEmojiByShortCode(match) {
         // find emoji by shortcode - full match or with-out last char as it could be from text e.g. :-), 
@@ -32,7 +40,7 @@ function plugin(settings) {
         visit(tree, 'text', function(node) {
             node.value = node.value.replace(RE_EMOJI, getEmoji);
             
-            if (!RE_EMOJI.test(node.value)) {
+            if (!RE_EMOJI.test(node.value) && emoticonEnable) {
                 // emoji regex not matching --> check if shortcode
                 node.value = node.value.replace(RE_SHORT, getEmojiByShortCode);
             }

--- a/index.js
+++ b/index.js
@@ -37,9 +37,10 @@ function plugin(options) {
 
     function transformer(tree) {
         visit(tree, 'text', function(node) {
-            node.value = node.value.replace(RE_EMOJI, getEmoji);
+            before = node.value;
+            node.value = before.replace(RE_EMOJI, getEmoji);
             
-            if (!RE_EMOJI.test(node.value) && emoticonEnable) {
+            if (emoticonEnable && node.value === before) {
                 // emoji regex not matching --> check if shortcode
                 node.value = node.value.replace(RE_SHORT, getEmojiByShortCode);
             }

--- a/index.js
+++ b/index.js
@@ -11,7 +11,6 @@ const DEFAULT_SETTINGS = {
 };
 
 function plugin(options) {
-    //const pad = !!(settings || {}).padSpaceAfter;
     const settings = Object.assign(DEFAULT_SETTINGS, options);
     const pad = !!settings.padSpaceAfter;
     const emoticonEnable = !!settings.emoticon;

--- a/index.js
+++ b/index.js
@@ -3,7 +3,7 @@ const emoji = require('node-emoji');
 const emoticon = require('emoticon');
 
 const RE_EMOJI = /:\+1:|:-1:|:[\w-]+:/g;
-const RE_SHORT = /[$@|*',;.=:\-)([\]\\/<>038BOopPsdDxXzZ]{2,5}/g;
+const RE_SHORT = /[$@|*',;.=:\-)([\]\\/<>038BOopPsSdDxXzZ]{2,5}/g;
 
 function plugin(settings) {
     const pad = !!(settings || {}).padSpaceAfter;

--- a/index_test.js
+++ b/index_test.js
@@ -49,9 +49,9 @@ describe('remark-emoji', () => {
 
     it('replaces in link text', () => {
         const cases = {
-            'In inline code, `:dog: is not replaced`': 'In inline code, `:dog: is not replaced`\n',
-            'In code, \n```\n:dog: is not replaced\n```': 'In code, \n\n    :dog: is not replaced\n',
-            '[here :dog: and :cat: pictures!](https://example.com)': '[here 🐶 and 🐱 pictures!](https://example.com)\n'
+            'In inline code, `:dog: and :-) is not replaced`': 'In inline code, `:dog: and :-) is not replaced`\n',
+            'In code, \n```\n:dog: and :-) is not replaced\n```': 'In code, \n\n    :dog: and :-) is not replaced\n',
+            '[here :dog: and :cat: and :-) pictures!](https://example.com)': '[here 🐶 and 🐱 and 😃 pictures!](https://example.com)\n'
         };
 
         return Promise.all(
@@ -68,7 +68,9 @@ describe('remark-emoji', () => {
             ':dog: is dog': '🐶  is dog\n',
             'dog is :dog:': 'dog is 🐶 \n',
             ':dog: is not :cat:': '🐶  is not 🐱 \n',
-            ':triumph:': '😤 \n'
+            ':triumph:': '😤 \n',
+            ':-)': '😃 \n',
+            'Smile :-), not >:(!': 'Smile 😃 , not 😠 !\n'
         };
 
         return Promise.all(
@@ -80,6 +82,20 @@ describe('remark-emoji', () => {
         const cases = {
             'The Antarctic flag is represented by :flag-aq:': 'The Antarctic flag is represented by 🇦🇶\n',
             ':man-woman-girl-boy:': '👨‍👩‍👧‍👦\n'
+        };
+
+        return Promise.all(
+            Object.keys(cases).map(c => process(c).then(r => assert.equal(r, cases[c])))
+        );
+    });
+
+    it('can handle emoji shortcodes (emoticon)', () => {
+        const cases = {
+            ':p': '😛\n',
+            ':-)': '😃\n',
+            'With-in some text :-p, also with some  :o spaces :-)!': 'With-in some text 😛, also with some  😮 spaces 😃!\n',
+            'Four char code ]:-)': 'Four char code 😈\n',
+            'No problem with :dog: - :d': 'No problem with 🐶 - 😛\n'
         };
 
         return Promise.all(

--- a/index_test.js
+++ b/index_test.js
@@ -5,7 +5,7 @@ const headings = require('remark-autolink-headings');
 const slug = require('remark-slug');
 const emoji = require('.');
 
-const compiler = remark().use(github).use(headings).use(slug).use(emoji);
+const compiler = remark().use(github).use(headings).use(slug).use(emoji, {emoticon: true});
 const padded = remark().use(github).use(headings).use(slug).use(emoji, {padSpaceAfter: true});
 
 function process(contents) {

--- a/index_test.js
+++ b/index_test.js
@@ -95,7 +95,8 @@ describe('remark-emoji', () => {
             ':-)': '😃\n',
             'With-in some text :-p, also with some  :o spaces :-)!': 'With-in some text 😛, also with some  😮 spaces 😃!\n',
             'Four char code ]:-)': 'Four char code 😈\n',
-            'No problem with :dog: - :d': 'No problem with 🐶 - 😛\n'
+            'No problem with :dog: - :d': 'No problem with 🐶 - 😛\n',
+            'With double quotes :"D': 'With double quotes 😊\n'
         };
 
         return Promise.all(

--- a/index_test.js
+++ b/index_test.js
@@ -38,7 +38,7 @@ describe('remark-emoji', () => {
     it('does not replace emoji-like but not-a-emoji stuffs', () => {
         const cases = {
             'This text does not include emoji.': 'This text does not include emoji.\n',
-            ':++: or :foo: or :dog': ':++: or :foo: or :dog\n',
+            ':++: or :foo: or :cat': ':++: or :foo: or :cat\n',
             '::': '::\n'
         };
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -316,6 +316,11 @@
       "integrity": "sha1-xs0OwbBkLio8Z6ETfvxeeW2k+I4=",
       "dev": true
     },
+    "emoticon": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/emoticon/-/emoticon-3.2.0.tgz",
+      "integrity": "sha512-SNujglcLTTg+lDAcApPNgEdudaqQFiAbJCqzjNxJkvN9vAwCGi0uu8IUVvx+f16h+V44KCY6Y2yboroc9pilHg=="
+    },
     "escape-string-regexp": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "remark-slug": "^4.2.2"
   },
   "dependencies": {
+    "emoticon": "^3.2.0",
     "node-emoji": "^1.8.1",
     "unist-util-visit": "^1.4.0"
   }


### PR DESCRIPTION
I'm working on a PR to Boostnote.next and there I'm using your plugin.

It's working but I'd like to have emoticon support. What do you think, is this something you'd like to add?

If you don't like it, no problem - I could also create a separate plugin for it. But I think it would be good to have it. Then it got similar features like retext-emoji as you can see in the following [demo](https://retextjs.github.io/retext-emoji/).

**So what will be added?**
You can write :-) and it will be replaced with 😃. It's using [emoticon](https://www.npmjs.com/package/emoticon) for the shortcodes and icons.

The regex is matching every shortcode from `index.json` of emoticon as you can see [here](https://regex101.com/r/BuynMZ/2) - the " and [ match is a bit confusing in the regex101 but it's working as the markdown is with-out these additional chars.  (Just the key `emoticons` need to be matched.)

I've added some test cases. So it should be fully tested but please let me know if I've missed a case.