### PR TITLE
use actions/setup-node v2 for GitHub Actions CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
         node: ['12', '14']
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/setup-node@v1
+      - uses: actions/setup-node@v2
         with:
           node-version: ${{ matrix.node }}
       - run: npm ci
@@ -21,6 +21,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/setup-node@v1
+      - uses: actions/setup-node@v2
       - run: npm ci
       - run: npm run lint


### PR DESCRIPTION
## Changes:

- Update `actions/setup-node` from `v1` -> `v2`

## Context:

`v2` is the latest stable release of `actions/setup-node`. It's a good idea to keep your actions up to date.

Release notes for `actions/setup-node` can be found here: https://github.com/actions/setup-node/releases