### PR TITLE
Update node-emoji and npm audit fix

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "license": "MIT",
       "dependencies": {
         "emoticon": "^3.2.0",
-        "node-emoji": "^1.10.0",
+        "node-emoji": "^1.11.0",
         "unist-util-visit": "^2.0.3"
       },
       "devDependencies": {
@@ -141,12 +141,12 @@
       "dev": true
     },
     "node_modules/@definitelytyped/utils": {
-      "version": "0.0.76",
-      "resolved": "https://registry.npmjs.org/@definitelytyped/utils/-/utils-0.0.76.tgz",
-      "integrity": "sha512-4CGsy64pyQqi/8gKThHKsxvcNaj3dCAzk0KL3vZ2l02feLfkVoVHrQo1avvrWQ1nw98Vwrpy9VzqgBDW515hhA==",
+      "version": "0.0.85",
+      "resolved": "https://registry.npmjs.org/@definitelytyped/utils/-/utils-0.0.85.tgz",
+      "integrity": "sha512-GHfMwIroQf3jrvps3a0rClpm5thyHajXGkMUTk4tJ4ew5I53wCnJSPMwlknsFD70F7a1hNDJGySu0PRg4px32Q==",
       "dev": true,
       "dependencies": {
-        "@definitelytyped/typescript-versions": "^0.0.76",
+        "@definitelytyped/typescript-versions": "^0.0.85",
         "@types/node": "^14.14.35",
         "charm": "^1.0.2",
         "fs-extra": "^8.1.0",
@@ -155,6 +155,12 @@
         "tar": "^2.2.2",
         "tar-stream": "^2.1.4"
       }
+    },
+    "node_modules/@definitelytyped/utils/node_modules/@definitelytyped/typescript-versions": {
+      "version": "0.0.85",
+      "resolved": "https://registry.npmjs.org/@definitelytyped/typescript-versions/-/typescript-versions-0.0.85.tgz",
+      "integrity": "sha512-+yHqi887UMZ4TlLBkA2QcYNP/EZSKGKSAFJtSWY6J5DiBQq3k0yLN1yTfbLonQ52IBenI1iJo/4ePr5A3co5ZQ==",
+      "dev": true
     },
     "node_modules/@definitelytyped/utils/node_modules/fs-extra": {
       "version": "8.1.0",
@@ -1030,9 +1036,9 @@
       }
     },
     "node_modules/dtslint": {
-      "version": "4.0.8",
-      "resolved": "https://registry.npmjs.org/dtslint/-/dtslint-4.0.8.tgz",
-      "integrity": "sha512-ypMFCfHwWmbELC1xXS3dJ+tPt/iAc6emWpIdavtV7ubsmzc9wVd2joa7RS/3yQ9g9EPBwylIWMSMf/bItS1Dbw==",
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/dtslint/-/dtslint-4.1.3.tgz",
+      "integrity": "sha512-UHW14DNpWnE5GkmORiDP0f4pc3AvgV7N0grB0skamXyExGOsbsHtNIe+8xeuAkPCrsf10O+Ph3W6+UgXvE4fiA==",
       "dev": true,
       "dependencies": {
         "@definitelytyped/header-parser": "latest",
@@ -1848,9 +1854,9 @@
       }
     },
     "node_modules/hosted-git-info": {
-      "version": "2.8.8",
-      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.8.tgz",
-      "integrity": "sha512-f/wzC2QaWBs7t9IYqB4T3sR1xviIViXJRJTWBlx2Gf3g0Xi5vI7Yy4koXQ1c9OYDGHN9sBy1DQ2AB8fqZBWhUg==",
+      "version": "2.8.9",
+      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.9.tgz",
+      "integrity": "sha512-mxIDAb9Lsm6DoOJ7xH+5+X4y1LU/4Hi50L9C5sIswK3JzULS4bwk1FvjdBgvYR4bzT4tuUQiC15FE2f5HbLvYw==",
       "dev": true
     },
     "node_modules/http-signature": {
@@ -2365,8 +2371,7 @@
     "node_modules/lodash": {
       "version": "4.17.21",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
-      "dev": true
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
     },
     "node_modules/lodash.clonedeep": {
       "version": "4.5.0",
@@ -2379,11 +2384,6 @@
       "resolved": "https://registry.npmjs.org/lodash.flatten/-/lodash.flatten-4.4.0.tgz",
       "integrity": "sha1-8xwiIlqWMtK7+OSt2+8kCqdlph8=",
       "dev": true
-    },
-    "node_modules/lodash.toarray": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/lodash.toarray/-/lodash.toarray-4.4.0.tgz",
-      "integrity": "sha1-JMS/zWsvuji/0FlNsRedjptlZWE="
     },
     "node_modules/lodash.truncate": {
       "version": "4.4.2",
@@ -2795,11 +2795,11 @@
       "dev": true
     },
     "node_modules/node-emoji": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/node-emoji/-/node-emoji-1.10.0.tgz",
-      "integrity": "sha512-Yt3384If5H6BYGVHiHwTL+99OzJKHhgp82S8/dktEK73T26BazdgZ4JZh92xSVtGNJvz9UbXdNAc5hcrXV42vw==",
+      "version": "1.11.0",
+      "resolved": "https://registry.npmjs.org/node-emoji/-/node-emoji-1.11.0.tgz",
+      "integrity": "sha512-wo2DpQkQp7Sjm2A0cq+sN7EHKO6Sl0ctXeBdFZrL9T9+UywORbufTcTZxom8YqpLQt/FqNMUkOpkZrJVYSKD3A==",
       "dependencies": {
-        "lodash.toarray": "^4.4.0"
+        "lodash": "^4.17.21"
       }
     },
     "node_modules/normalize-package-data": {
@@ -3294,9 +3294,9 @@
       }
     },
     "node_modules/path-parse": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.6.tgz",
-      "integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw==",
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
+      "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
       "dev": true
     },
     "node_modules/path-type": {
@@ -4951,12 +4951,12 @@
       "dev": true
     },
     "@definitelytyped/utils": {
-      "version": "0.0.76",
-      "resolved": "https://registry.npmjs.org/@definitelytyped/utils/-/utils-0.0.76.tgz",
-      "integrity": "sha512-4CGsy64pyQqi/8gKThHKsxvcNaj3dCAzk0KL3vZ2l02feLfkVoVHrQo1avvrWQ1nw98Vwrpy9VzqgBDW515hhA==",
+      "version": "0.0.85",
+      "resolved": "https://registry.npmjs.org/@definitelytyped/utils/-/utils-0.0.85.tgz",
+      "integrity": "sha512-GHfMwIroQf3jrvps3a0rClpm5thyHajXGkMUTk4tJ4ew5I53wCnJSPMwlknsFD70F7a1hNDJGySu0PRg4px32Q==",
       "dev": true,
       "requires": {
-        "@definitelytyped/typescript-versions": "^0.0.76",
+        "@definitelytyped/typescript-versions": "^0.0.85",
         "@types/node": "^14.14.35",
         "charm": "^1.0.2",
         "fs-extra": "^8.1.0",
@@ -4966,6 +4966,12 @@
         "tar-stream": "^2.1.4"
       },
       "dependencies": {
+        "@definitelytyped/typescript-versions": {
+          "version": "0.0.85",
+          "resolved": "https://registry.npmjs.org/@definitelytyped/typescript-versions/-/typescript-versions-0.0.85.tgz",
+          "integrity": "sha512-+yHqi887UMZ4TlLBkA2QcYNP/EZSKGKSAFJtSWY6J5DiBQq3k0yLN1yTfbLonQ52IBenI1iJo/4ePr5A3co5ZQ==",
+          "dev": true
+        },
         "fs-extra": {
           "version": "8.1.0",
           "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
@@ -5640,9 +5646,9 @@
       }
     },
     "dtslint": {
-      "version": "4.0.8",
-      "resolved": "https://registry.npmjs.org/dtslint/-/dtslint-4.0.8.tgz",
-      "integrity": "sha512-ypMFCfHwWmbELC1xXS3dJ+tPt/iAc6emWpIdavtV7ubsmzc9wVd2joa7RS/3yQ9g9EPBwylIWMSMf/bItS1Dbw==",
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/dtslint/-/dtslint-4.1.3.tgz",
+      "integrity": "sha512-UHW14DNpWnE5GkmORiDP0f4pc3AvgV7N0grB0skamXyExGOsbsHtNIe+8xeuAkPCrsf10O+Ph3W6+UgXvE4fiA==",
       "dev": true,
       "requires": {
         "@definitelytyped/header-parser": "latest",
@@ -6269,9 +6275,9 @@
       "dev": true
     },
     "hosted-git-info": {
-      "version": "2.8.8",
-      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.8.tgz",
-      "integrity": "sha512-f/wzC2QaWBs7t9IYqB4T3sR1xviIViXJRJTWBlx2Gf3g0Xi5vI7Yy4koXQ1c9OYDGHN9sBy1DQ2AB8fqZBWhUg==",
+      "version": "2.8.9",
+      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.9.tgz",
+      "integrity": "sha512-mxIDAb9Lsm6DoOJ7xH+5+X4y1LU/4Hi50L9C5sIswK3JzULS4bwk1FvjdBgvYR4bzT4tuUQiC15FE2f5HbLvYw==",
       "dev": true
     },
     "http-signature": {
@@ -6633,8 +6639,7 @@
     "lodash": {
       "version": "4.17.21",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
-      "dev": true
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
     },
     "lodash.clonedeep": {
       "version": "4.5.0",
@@ -6647,11 +6652,6 @@
       "resolved": "https://registry.npmjs.org/lodash.flatten/-/lodash.flatten-4.4.0.tgz",
       "integrity": "sha1-8xwiIlqWMtK7+OSt2+8kCqdlph8=",
       "dev": true
-    },
-    "lodash.toarray": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/lodash.toarray/-/lodash.toarray-4.4.0.tgz",
-      "integrity": "sha1-JMS/zWsvuji/0FlNsRedjptlZWE="
     },
     "lodash.truncate": {
       "version": "4.4.2",
@@ -6960,11 +6960,11 @@
       "dev": true
     },
     "node-emoji": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/node-emoji/-/node-emoji-1.10.0.tgz",
-      "integrity": "sha512-Yt3384If5H6BYGVHiHwTL+99OzJKHhgp82S8/dktEK73T26BazdgZ4JZh92xSVtGNJvz9UbXdNAc5hcrXV42vw==",
+      "version": "1.11.0",
+      "resolved": "https://registry.npmjs.org/node-emoji/-/node-emoji-1.11.0.tgz",
+      "integrity": "sha512-wo2DpQkQp7Sjm2A0cq+sN7EHKO6Sl0ctXeBdFZrL9T9+UywORbufTcTZxom8YqpLQt/FqNMUkOpkZrJVYSKD3A==",
       "requires": {
-        "lodash.toarray": "^4.4.0"
+        "lodash": "^4.17.21"
       }
     },
     "normalize-package-data": {
@@ -7348,9 +7348,9 @@
       "dev": true
     },
     "path-parse": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.6.tgz",
-      "integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw==",
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
+      "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
       "dev": true
     },
     "path-type": {

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
   },
   "dependencies": {
     "emoticon": "^3.2.0",
-    "node-emoji": "^1.10.0",
+    "node-emoji": "^1.11.0",
     "unist-util-visit": "^2.0.3"
   }
 }


### PR DESCRIPTION
I updated `node-emoji` from `1.10.0` to `1.11.0` and I ran `npm audit fix`.