### PR TITLE
prevent mid-word emoticons

### DIFF
--- a/test.ts
+++ b/test.ts
@@ -200,6 +200,9 @@ describe('remark-emoji', function () {
 
         it('handles emoji shortcodes (emoticon)', async function () {
             const tests: Record<string, string> = {
+                'with space :o, and comma': 'with space 😮, and comma\n',
+                'WARN:Danger': 'WARN:Danger\n',
+                'https://github.com': 'https://github.com\n',
                 ':p': '😛\n',
                 ':-)': '😃\n',
                 'With-in some text :-p, also with some  :o spaces :-)!':


### PR DESCRIPTION
Fixes emoticon support, so it doesn't turn characters in the middle of words into shortcode emojis.  This issue was raised in #35.

Unlike the proposed fix in #35, this PR grabs the value before the matching emoticon string and does a compare similar to the character after as well.  This works better than the lookbehind request because it is better supported, the lookbehind operator has a little less than [93% adoption](https://caniuse.com/js-regexp-lookbehind), good but not great.  This PR has better support by doing some extra manual processing.